### PR TITLE
Add leading whitespace test

### DIFF
--- a/ast/file_info_test.go
+++ b/ast/file_info_test.go
@@ -1,0 +1,35 @@
+package ast_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/jhump/protocompile/ast"
+	"github.com/jhump/protocompile/parser"
+	"github.com/jhump/protocompile/reporter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLeadingWhitespace(t *testing.T) {
+	const path = "../internal/testprotos/desc_test_leading_whitespace.proto"
+	data, err := ioutil.ReadFile(path)
+	require.NoError(t, err)
+	fileNode, err := parser.Parse(filepath.Base(path), bytes.NewReader(data), reporter.NewHandler(nil))
+	require.NoError(t, err)
+	require.NoError(
+		t,
+		ast.Walk(
+			fileNode,
+			&ast.SimpleVisitor{
+				DoVisitMessageNode: func(messageNode *ast.MessageNode) error {
+					info := fileNode.NodeInfo(messageNode.Keyword)
+					assert.Empty(t, info.LeadingWhitespace(), "%s should not have leading whitespace", messageNode.Name.Val)
+					return nil
+				},
+			},
+		),
+	)
+}

--- a/internal/testprotos/desc_test_leading_whitespace.proto
+++ b/internal/testprotos/desc_test_leading_whitespace.proto
@@ -1,0 +1,12 @@
+syntax = "proto2";
+
+// Foo has no leading whitespace.
+message Foo {};
+
+// Baz also doesn't even though it has two
+// leading comments.
+message Bar {};
+
+// Baz does because it has a C-style comment.
+/* Like this. */
+message Baz {};


### PR DESCRIPTION
There's an inconsistency with how leading whitespace is tracked between a node and its leading comments if the comments are C-style `/* like this */`.

In this case, none of the messages in the test should have any leading whitespace, but the `Baz` message does:

```protobuf
syntax = "proto2";

// Foo has no leading whitespace.
message Foo {};

// Baz also doesn't even though it has two
// leading comments.
message Bar {};

// Baz does because it has a C-style comment.
/* Like this. */
message Baz {};
```