### PR TITLE
match the algorithm for comment attribution suggested in upcoming descriptor production docs

### DIFF
--- a/ast/file_info.go
+++ b/ast/file_info.go
@@ -299,9 +299,15 @@ func (n NodeInfo) RawText() string {
 
 // SourcePos identifies a location in a proto source file.
 type SourcePos struct {
-	Filename  string
+	Filename string
+	// The line and column numbers for this position. These are
+	// one-based, so the first line and column is 1 (not zero). If
+	// either is zero, then the line and column are unknown and
+	// only the file name is known.
 	Line, Col int
-	Offset    int
+	// The offset, in bytes, from the beginning of the file. This
+	// is zero-based: the first character in the file is offset zero.
+	Offset int
 }
 
 func (pos SourcePos) String() string {


### PR DESCRIPTION
In a private repo, I am working on documentation with lots of details on implementing a compiler, including details of descriptor production that are not really spelled out in the comments in `descriptor.proto`.

In that doc is a suggested algorithm for attributing comments to tokens. That algorithm is a little better/more clear than what we were doing here. And yet it's close enough to what we were doing that the new algorithm still passes the source code info tests in here.

The new code is still kind of ugly and hard to read. But it's _less_ atrocious 😛! Especially when looking at it next to the algorithm doc, since one can more clearly see how the code matches the described procedure.